### PR TITLE
Issue feat: set setloading false if there is no child data for TL Block

### DIFF
--- a/src/components/CohortSelectionSection.tsx
+++ b/src/components/CohortSelectionSection.tsx
@@ -303,7 +303,10 @@ const CohortSelectionSection: React.FC<CohortSelectionSectionProps> = ({
 
 
               setCohortsData(filteredData);
-
+               if(response[0].childData.length===0)
+               {
+                    setLoading(false);
+               }
               if (filteredData.length > 0) {
                 if (typeof window !== 'undefined' && window.localStorage) {
                   const cohort = localStorage.getItem('classId') || '';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved loading state management when processing cohort data
	- Ensured loading indicator is correctly disabled when no child data is present

<!-- end of auto-generated comment: release notes by coderabbit.ai -->