### PR TITLE
Issue #PS-3698 fix: When tried to filter centre's based on names, its not filtering

### DIFF
--- a/src/pages/centers/index.tsx
+++ b/src/pages/centers/index.tsx
@@ -56,7 +56,7 @@ const CentersPage = () => {
   const [filteredCenters, setFilteredCenters] = useState(centerData);
   const [searchInput, setSearchInput] = useState('');
   const [selectedCenters, setSelectedCenters] = useState<string[]>([]);
-  const [sortOrder, setSortOrder] = useState('');
+  const [sortOrder, setSortOrder] = useState('asc');
   const [centerType, setCenterType] = useState<'regular' | 'remote' | ''>('');
   const [appliedFilters, setAppliedFilters] = useState({
     centerType: '',
@@ -557,8 +557,7 @@ const CentersPage = () => {
                       <CenterList
                         title="CENTERS.REMOTE_CENTERS"
                         centers={filteredCenters
-                          .filter((center) => center.centerType?.toUpperCase() === CenterType.REMOTE)
-                          .sort((a, b) => (a.cohortName || "").localeCompare(b.cohortName || ""))}
+                          .filter((center) => center.centerType?.toUpperCase() === CenterType.REMOTE)}
                         router={router}
                         theme={theme}
                         t={t}


### PR DESCRIPTION
…not filtering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The centers list now defaults to an ascending sort order.
	- Remote centers are displayed in their original retrieval order without additional sorting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->