### PR TITLE
Issue #00000 : In the teacher app, where the class name is too long, …

### DIFF
--- a/src/pages/centers/index.tsx
+++ b/src/pages/centers/index.tsx
@@ -491,8 +491,10 @@ const CentersPage = () => {
                           <Grid
                             item
                             xs={12}
-                            sm={6}
-                            md={4}
+                            sm={12}
+                            md={12}
+                            lg={6}
+                            xl={4}
                             key={cohort?.cohortId}
                           >
                             <Box


### PR DESCRIPTION
…it overlaps with the boundary of the textbox under My Classes section