### PR TITLE
 Prevent crash in /forgot-password by safely accessing error response

### DIFF
--- a/src/pages/forgot-password/index.tsx
+++ b/src/pages/forgot-password/index.tsx
@@ -55,7 +55,7 @@ const ForgotPassword = () => {
 
       setSuccessMessage(true);
     } catch (error: any) {
-      const errorMessage = error?.response?.data?.params?.err || "Something went wrong";
+      const errorMessage = error?.response?.data?.params?.err ?? "Something went wrong";
       showToastMessage(errorMessage, 'error');
     }
   };

--- a/src/pages/forgot-password/index.tsx
+++ b/src/pages/forgot-password/index.tsx
@@ -55,7 +55,8 @@ const ForgotPassword = () => {
 
       setSuccessMessage(true);
     } catch (error: any) {
-      showToastMessage(error.response.data.params.err, 'error');
+      const errorMessage = error?.response?.data?.params?.err || "Something went wrong";
+      showToastMessage(errorMessage, 'error');
     }
   };
 


### PR DESCRIPTION
## Summary

This PR fixes an unhandled runtime error that occurred in the /forgot-password flow. The app was trying to read `error.response.data.params.err` without checking if `response` exists, which caused a crash when `response` was undefined (e.g., during a network failure).

Closes #737 

## Before

The app crashed with:

![Screenshot 2025-05-04 144726](https://github.com/user-attachments/assets/c26d3f53-ed18-4b54-a4ee-685f5e718d3c)


## After

Graceful error handling with a toast message instead of crashing.
![Screenshot 2025-05-04 150122](https://github.com/user-attachments/assets/7ab068c2-499f-4405-a5b8-98d020b1a130)


## Why

To avoid confusing crashes for users and ensure smoother UX in edge cases like network issues.


## Changes

- Added optional chaining (`?.`)
- Added a fallback error message `'Something went wrong'` if the expected message is unavailable

## sidenote

I looked through all of the code base, which was huge and found this one inconsistency, took me hours so i hope i can get an acknowledgement.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling on the forgot password page to ensure clearer messages and prevent potential crashes when submitting the form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->